### PR TITLE
Always check for cookie if header is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 - Callables for before, after and error handlers are not assumed to be instance of a `Closure`.
+- Cookie was ignored if if using /(.*)/ as regexp and the configured header was missing from request ([#17](https://github.com/tuupola/branca-middleware/pull/17)).
 
 ## [0.5.2](https://github.com/tuupola/branca-middleware/compare/0.5.1...0.5.2) - 2019-01-09
 ### Added

--- a/src/BrancaAuthentication.php
+++ b/src/BrancaAuthentication.php
@@ -234,16 +234,14 @@ final class BrancaAuthentication implements MiddlewareInterface
      */
     private function fetchToken(ServerRequestInterface $request): string
     {
-        $header = "";
-        $message = "Using token from request header";
-
         /* Check for token in header. */
-        $headers = $request->getHeader($this->options["header"]);
-        $header = isset($headers[0]) ? $headers[0] : "";
+        $header = $request->getHeaderLine($this->options["header"]);
 
-        if (preg_match($this->options["regexp"], $header, $matches)) {
-            $this->log(LogLevel::DEBUG, $message);
-            return $matches[1];
+        if (false === empty($header)) {
+            if (preg_match($this->options["regexp"], $header, $matches)) {
+                $this->log(LogLevel::DEBUG, "Using token from request header");
+                return $matches[1];
+            }
         }
 
         /* Token not found in header try a cookie. */

--- a/tests/BrancaAuthenticationTest.php
+++ b/tests/BrancaAuthenticationTest.php
@@ -160,6 +160,32 @@ class BrancaAuthenticationTest extends TestCase
         $this->assertEquals("Success", $response->getBody());
     }
 
+    public function testShouldUseCookieIfHeaderMissing()
+    {
+        $request = (new ServerRequestFactory)
+            ->createServerRequest("GET", "https://example.com/api")
+            ->withCookieParams(["token" => self::$token]);
+
+        $default = function (RequestInterface $request) {
+            $response = (new ResponseFactory)->createResponse();
+            $response->getBody()->write("Success");
+            return $response;
+        };
+
+        $collection = new MiddlewareCollection([
+            new BrancaAuthentication([
+                "secret" => "supersecretkeyyoushouldnotcommit",
+                "header" => "X-Token",
+                "regexp" => "/(.*)/",
+            ])
+        ]);
+
+        $response = $collection->dispatch($request, $default);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals("Success", $response->getBody());
+    }
+
     public function testShouldAlterResponseWithAfter()
     {
         $request = (new ServerRequestFactory)


### PR DESCRIPTION
There was a false negative if header was missing and using `/(.*)/` as regexp. See https://github.com/tuupola/slim-jwt-auth/issues/156 for reference.